### PR TITLE
Better handling than just except: pass for short term load script

### DIFF
--- a/pipeline/load_short_term.py
+++ b/pipeline/load_short_term.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 import numpy as np
 import pandas as pd
 import psycopg2
+import psycopg2.errors
 import psycopg2.extras
 import psycopg2.extensions
 
@@ -47,8 +48,12 @@ def insert_dataframe_into_origin_table(connection: psycopg2.extensions.connectio
                         "INSERT INTO origin (longitude, latitude, country, continent) VALUES (%s, %s, %s, %s);", row.to_list())
                     connection.commit()
 
+        except psycopg2.errors.UniqueViolation as e:
+            pass  # We don't want duplicate values, but also don't want to crash
         except:
-            pass
+            print("Unexpected Error Ocurred")
+            print(e.args)
+            print(str(e))
 
 
 def insert_dataframe_into_botanist_table(connection: psycopg2.extensions.connection, dataframe: pd.DataFrame) -> None:
@@ -62,8 +67,12 @@ def insert_dataframe_into_botanist_table(connection: psycopg2.extensions.connect
                         "INSERT INTO botanist (name, email, phone) VALUES (%s, %s, %s);", row.to_list())
                     connection.commit()
 
+        except psycopg2.errors.UniqueViolation as e:
+            pass  # We don't want duplicate values, but also don't want to crash
         except:
-            pass
+            print("Unexpected Error Ocurred")
+            print(e.args)
+            print(str(e))
 
 
 def add_origin_ids_to_plant_df(connection: psycopg2.extensions.connection, total_dataframe: pd.DataFrame, plant_dataframe: pd.DataFrame) -> pd.DataFrame:
@@ -96,8 +105,12 @@ def insert_dataframe_into_plant_table(connection: psycopg2.extensions.connection
                         "INSERT INTO plant (plant_name, scientific_name, cycle, sunlight, api_id, origin_id) VALUES (%s, %s, %s, %s, %s, %s);", row.to_list())
                     connection.commit()
 
+        except psycopg2.errors.UniqueViolation as e:
+            pass  # We don't want duplicate values, but also don't want to crash
         except:
-            pass
+            print("Unexpected Error Ocurred")
+            print(e.args)
+            print(str(e))
 
 
 def insert_dataframe_into_sensor_result_table(connection: psycopg2.extensions.connection, dataframe: pd.DataFrame) -> None:


### PR DESCRIPTION
Before I just had 
```
try:
  something that might enter duplicates into db
except:
  pass
 ```

Now it'll print if some other error happens, and only pass if specifically the duplicate rows error occurs