### PR TITLE
fixed empty availability ids in database

### DIFF
--- a/pipeline/load_short_term.py
+++ b/pipeline/load_short_term.py
@@ -143,8 +143,14 @@ def add_availability_ids_to_sensor_df(connection: psycopg2.extensions.connection
                 "SELECT availability_id FROM plant_availability WHERE type_of_availability LIKE %s;", (str(row["error"]),))
             current_availability_id = cur.fetchone()
 
+        # The below section is not very clear, so to clarify what's happening here:
+        # If current_availability_id is None, that means there were no error messages from the API
+        # (This is because our SQL and csv column names have diverged a bit.)
+        # If there are no errors (the sensor worked fine), append 1 to the list.
+        # The schema is set up so that 1 is the key for No Error
+
         if current_availability_id is None:
-            availability_ids.append(None)
+            availability_ids.append(1)
         else:
             availability_ids.append(
                 current_availability_id["availability_id"])

--- a/pipeline/load_short_term.py
+++ b/pipeline/load_short_term.py
@@ -143,12 +143,6 @@ def add_availability_ids_to_sensor_df(connection: psycopg2.extensions.connection
                 "SELECT availability_id FROM plant_availability WHERE type_of_availability LIKE %s;", (str(row["error"]),))
             current_availability_id = cur.fetchone()
 
-        # The below section is not very clear, so to clarify what's happening here:
-        # If current_availability_id is None, that means there were no error messages from the API
-        # (This is because our SQL and csv column names have diverged a bit.)
-        # If there are no errors (the sensor worked fine), append 1 to the list.
-        # The schema is set up so that 1 is the key for No Error
-
         if current_availability_id is None:
             availability_ids.append(1)
         else:

--- a/pipeline/rds_schema.sql
+++ b/pipeline/rds_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE plant_availability(
 );
 
 -- Currently these are the only errors/availability results
-INSERT INTO plant_availability (type_of_availability) VALUES ('None');
+INSERT INTO plant_availability (type_of_availability) VALUES ('No Error');
 INSERT INTO plant_availability (type_of_availability) VALUES ('plant on loan to another museum');
 INSERT INTO plant_availability (type_of_availability) VALUES ('plant not found');
 INSERT INTO plant_availability (type_of_availability) VALUES ('Timeout: The request could not be completed.');


### PR DESCRIPTION
Availability ID's had a lot of empty entries in the SQL database previously (Whenever there was no error - which is most of the time)

This is quite a messy fix (although it works, now there's always an availability id)

An alternative fix would be to edit the transform script to write something in error column when there's nothing wrong, e.g. "No Error", which load could then match up with the rows in the plant_availability table